### PR TITLE
adjust sed script, so flux.sh can run on OS X, too

### DIFF
--- a/src/main/scripts/flux.sh
+++ b/src/main/scripts/flux.sh
@@ -81,12 +81,14 @@ fi
 # a variable definition:
 vars_to_script=$( cat <<'EOF'
 	s/^[^=]*$//g ;                        # is this not a variable definition?
-	t quit ;                              # then jump to quit
+	                                      # then jump to quit
+	t quit
 	s/\\/\\\\/g ;                         # otherwise escape backslashes,
 	s/!/\\!/g ;                           # escape exclamation marks,
 	s/='(.*)'$/=\1/ ;                     # remove quotes,
 	s/^([^=]+)=(.*)$/s!\\$\1!\2!g ; /g ;  # convert to sed regexp command
-	b ;                                   # and continue with next line
+	                                      # and continue with next line
+	b
 	: quit
 	q
 EOF


### PR DESCRIPTION
[@nabatz](https://twitter.com/nabatz) and I noticed, that `flux.sh` does not run on OS X out of the box.

I have manually tested this patch on OS X 10.11.16 (El Capitan) and Linux (Ubuntu Xenial 16.04).

Sed is notoriosly divergent across Unixes (see for example [this question](http://unix.stackexchange.com/q/13711/376) on Unix.SE).

In this case, BSD sed failed with 'undefined label quit' (short [screencast](https://asciinema.org/a/2e9rtobgvc8q8ahpcr8ect1vz)).
