### PR TITLE
fix a weird macos classpath issue in flux.sh

### DIFF
--- a/src/main/scripts/flux.sh
+++ b/src/main/scripts/flux.sh
@@ -109,4 +109,5 @@ while read line ; do
 done < <( echo "$java_opts" | grep -Eo "$option_pattern" )
 
 # Start flux:
-"$FLUX_JAVA_BIN" "${java_opts_array[@]}" -jar "$jar_file" "$@"
+command=$(echo "$FLUX_JAVA_BIN" "${java_opts_array[@]}" -jar "$jar_file" "$@")
+$command


### PR DESCRIPTION
The line:

```
"$FLUX_JAVA_BIN" "${java_opts_array[@]}" -jar "$jar_file" "$@")
```

resulted in a

> Could not find or load main class"

error.

But when the verbatim command is executed in an interactive shell,
it all works fine.

Debugging with `-verbose:class` showed that the call from the script
and the interactive call resulted in a different set of classes loaded.
Especially the `culturegraph.*` classes were missed.

I cannot pin down the source of this bug.

But changing the failing line to:

```
command=$(echo "$FLUX_JAVA_BIN" "${java_opts_array[@]}" -jar "$jar_file" "$@")
$command
```

fixes the problem.

I have tested this patch successfully on Mac OS X 10.11.6 and Ubuntu 16.04.

This patch in combination with #9 would allow to run `flux.sh` on Mac OS X out of the box, which would be great.
